### PR TITLE
chore: post-display-bringup cleanups

### DIFF
--- a/app/src/app/cmd_sd.c
+++ b/app/src/app/cmd_sd.c
@@ -119,8 +119,9 @@ static int h_format(const uint8_t* req, uint32_t req_len, uint8_t* rsp, uint32_t
     if (atomic_compare_exchange_strong(&s_sd_fmt_busy, &expected, true))
     {
         /* Launch background format thread and return immediately */
-        k_thread_create(&sd_fmt_desc, sd_fmt_stack, K_THREAD_STACK_SIZEOF(sd_fmt_stack), sd_fmt_thread,
-                        NULL, NULL, NULL, K_LOWEST_APPLICATION_THREAD_PRIO, 0, K_NO_WAIT);
+        k_thread_create(&sd_fmt_desc, sd_fmt_stack, K_THREAD_STACK_SIZEOF(sd_fmt_stack),
+                        sd_fmt_thread, NULL, NULL, NULL, K_LOWEST_APPLICATION_THREAD_PRIO, 0,
+                        K_NO_WAIT);
         k_thread_name_set(&sd_fmt_desc, "sd_fmt");
         return 0;
     }

--- a/app/src/drivers/activity_led.c
+++ b/app/src/drivers/activity_led.c
@@ -28,8 +28,8 @@ int activity_led_init(void)
         return -ENODEV;
     }
     // NOLINTNEXTLINE(hicpp-signed-bitwise)
-    gpio_flags_t fl = (gpio_flags_t)((unsigned long)GPIO_OUTPUT |
-                                     (unsigned long)GPIO_OUTPUT_INIT_LOW);
+    gpio_flags_t fl =
+        (gpio_flags_t)((unsigned long)GPIO_OUTPUT | (unsigned long)GPIO_OUTPUT_INIT_LOW);
     int ret = gpio_pin_configure_dt(&led, fl);
     if (ret)
     {

--- a/app/src/drivers/error_indicator.c
+++ b/app/src/drivers/error_indicator.c
@@ -86,8 +86,8 @@ int error_indicator_init(void)
     if (led_ready)
     {
         // NOLINTNEXTLINE(hicpp-signed-bitwise)
-        gpio_flags_t fl = (gpio_flags_t)((unsigned long)GPIO_OUTPUT |
-                                         (unsigned long)GPIO_OUTPUT_INIT_LOW);
+        gpio_flags_t fl =
+            (gpio_flags_t)((unsigned long)GPIO_OUTPUT | (unsigned long)GPIO_OUTPUT_INIT_LOW);
         (void)gpio_pin_configure_dt(&led0, fl);
     }
 #else

--- a/app/src/drivers/heartbeat.c
+++ b/app/src/drivers/heartbeat.c
@@ -16,8 +16,7 @@ static K_THREAD_STACK_DEFINE(heartbeat_stack, 512);
 static struct k_thread heartbeat_thread;
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-static void heartbeat_entry(void* a, void* b,
-                            void* c)
+static void heartbeat_entry(void* a, void* b, void* c)
 {
     ARG_UNUSED(a);
     ARG_UNUSED(b);
@@ -47,8 +46,8 @@ int heartbeat_init(void)
     }
 
     // NOLINTNEXTLINE(hicpp-signed-bitwise)
-    gpio_flags_t fl = (gpio_flags_t)((unsigned long)GPIO_OUTPUT |
-                                     (unsigned long)GPIO_OUTPUT_INIT_LOW);
+    gpio_flags_t fl =
+        (gpio_flags_t)((unsigned long)GPIO_OUTPUT | (unsigned long)GPIO_OUTPUT_INIT_LOW);
     int ret = gpio_pin_configure_dt(&led, fl);
     if (ret)
     {

--- a/tests/unit/src/display/test_display_pixel_conv.cpp
+++ b/tests/unit/src/display/test_display_pixel_conv.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
-extern "C" {
+extern "C"
+{
 #include "display/pixel.h"
 }
 
@@ -16,4 +17,3 @@ TEST(DisplayPixel, Rgb888ToRgb565)
     EXPECT_EQ(pixel_rgb888_to_rgb565(0x20, 0x20, 0x20), 0x2104);
     EXPECT_EQ(pixel_rgb888_to_rgb565(0x80, 0x80, 0x80), 0x8410);
 }
-


### PR DESCRIPTION
- Wrap k_thread_create args for readability
- Consistent gpio flags formatting
- Heartbeat entry signature formatting
- GTest extern C style nit

No functional changes; host/unit + firmware builds OK.